### PR TITLE
fix: update F-Droid metadata

### DIFF
--- a/fdroid/com.rejowan.pdfreaderpro.yml
+++ b/fdroid/com.rejowan.pdfreaderpro.yml
@@ -3,7 +3,6 @@ Categories:
 License: GPL-3.0-only
 AuthorName: K M Rejowan Ahmmed
 AuthorEmail: kmrejowan@gmail.com
-WebSite: https://github.com/ahmmedrejowan/PdfReaderPro
 SourceCode: https://github.com/ahmmedrejowan/PdfReaderPro
 IssueTracker: https://github.com/ahmmedrejowan/PdfReaderPro/issues
 Changelog: https://github.com/ahmmedrejowan/PdfReaderPro/blob/master/CHANGELOG.md
@@ -16,7 +15,7 @@ Repo: https://github.com/ahmmedrejowan/PdfReaderPro.git
 Builds:
   - versionName: 2.1.3
     versionCode: 6
-    commit: v2.1.3
+    commit: 72645a976239a10f8464c72cf2bc7b3badefb967
     subdir: app
     gradle:
       - yes


### PR DESCRIPTION
- Use commit hash instead of tag
- Remove duplicate WebSite field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration source reference to use a specific commit hash instead of a tag reference, and removed metadata field from app distribution descriptor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->