### PR TITLE
chore: bump dependencies and fix repo language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Mark PDF.js assets as vendored so GitHub Linguist ignores them in language stats
+app/src/main/assets/** linguist-vendored

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,12 +6,12 @@ minSdk = "24"
 
 # Core Android
 agp = "9.1.0"
-kotlin = "2.3.10"
-coreKtx = "1.17.0"
+kotlin = "2.3.20"
+coreKtx = "1.18.0"
 
 # Compose
-composeBom = "2026.02.01"
-activityCompose = "1.12.4"
+composeBom = "2026.03.01"
+activityCompose = "1.13.0"
 lifecycleRuntimeCompose = "2.10.0"
 navigationCompose = "2.9.7"
 
@@ -19,17 +19,17 @@ navigationCompose = "2.9.7"
 room = "2.8.4"
 
 # DataStore
-datastore = "1.2.0"
+datastore = "1.2.1"
 
 # Koin
-koin = "4.1.1"
-koinCompose = "4.1.1"
+koin = "4.2.0"
+koinCompose = "4.2.0"
 
 # Kotlin Serialization
 kotlinxSerialization = "1.10.0"
 
 # Ktor HTTP Client
-ktor = "3.4.1"
+ktor = "3.4.2"
 
 
 # Image Loading
@@ -54,7 +54,7 @@ splashscreen = "1.2.0"
 webkit = "1.15.0"
 
 # iText PDF
-itext = "9.5.0"
+itext = "9.6.0"
 bouncycastle = "1.83"
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Sun Mar 01 19:22:34 BDT 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=60ea723356d81263e8002fec0fcf9e2b0eee0c0850c7a3d7ab0a63f2ccc601f3
+distributionSha256Sum=2ab2958f2a1e51120c326cad6f385153bb11ee93b3c216c5fccebfdfbb7ec6cb
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,6 +2,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionSha256Sum=60ea723356d81263e8002fec0fcf9e2b0eee0c0850c7a3d7ab0a63f2ccc601f3
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- Bump dependencies: Kotlin 2.3.20, Compose BOM 2026.03.01, Gradle 9.4.1, Koin 4.2.0, Ktor 3.4.2, iText 9.6.0, and others
- Add `.gitattributes` to mark PDF.js assets as vendored so GitHub shows the repo as Kotlin instead of JavaScript

## Test plan
- [ ] Verify project builds successfully with updated dependencies
- [ ] Confirm GitHub repo language stats show Kotlin as primary language after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to newer stable versions (Kotlin, Jetpack Compose BOM, AndroidX Core, Koin, Ktor, iText, DataStore).
  * Updated Gradle build system to 9.4.1.
  * Marked bundled app assets as vendored so they are excluded from repository language statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->