### PR TITLE
chore: prepare 2.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.3.0] - 2026-07-19
+
+### Added
+- **Page Slider on Scroll** - Setting (View Mode sheet) to control whether the page slider appears while scrolling when the toolbar is hidden; off by default (closes #54)
+
+### Changed
+- **In-PDF Search Navigation** - Next/previous now steps through every match across all pages reliably, and the active match is centered in the view (#40)
+- **Dependency Updates** - Kotlin 2.4.10, AGP 9.2.1, Android compile/target SDK 37, Compose BOM, and other core libraries
+
+### Fixed
+- **PDF Open Failure** - PDFs whose file path contained an apostrophe no longer get stuck on the loading screen (closes #57)
+
+---
+
 ## [2.2.0] - 2026-04-23
 
 ### Added

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -34,6 +34,15 @@ This document lists known issues and limitations in PDF Reader Pro, along with w
 
 ---
 
+### Search or copy returns wrong text in some non-English PDFs
+**Issue:** In some PDFs (often Indic scripts such as Hindi, Bengali, or Gujarati) the text renders correctly, but search, text selection, and copy return incorrect or scrambled characters. This happens when the PDF's embedded fonts carry an incomplete or incorrect `/ToUnicode` map — the correct characters are simply not stored in the file, so no reader can recover them.
+
+**Workaround:** Re-generate the PDF with a tool that embeds proper Unicode data (for example, "Print → Save as PDF" from Chrome). Note this affects every PDF viewer (including Adobe Reader and Chrome), not just this app.
+
+**Status:** Limitation of the PDF file itself, not fixable in the reader (#40)
+
+---
+
 ## PDF Tools
 
 ### Password-protected PDFs cannot be merged
@@ -133,7 +142,9 @@ Issues that have been fixed in recent releases:
 | Remember password not auto-filling (#43) | v2.2.0 | Saved password is now auto-submitted on reopen; stale entries cleaned up |
 | Double-tap zoom locked to 200% and top-left anchored (#42) | v2.2.0 | Zoom level is configurable (1.1×–5×) and now centers on the tapped point |
 | Reader/home chrome ignoring app theme | v2.2.0 | Colors routed through Material color scheme so Dark/Black themes apply |
+| PDFs with an apostrophe in the file path not opening (#57) | v2.3.0 | Fixed JS argument escaping so the document loads |
+| In-PDF search skipping matches / erratic arrow navigation | v2.3.0 | Search now traverses every match across all pages, with the active match centered |
 
 ---
 
-*Last updated: 2026-04-23*
+*Last updated: 2026-07-19*

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.rejowan.pdfreaderpro"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 7
-        versionName = "2.2.0"
+        versionCode = 8
+        versionName = "2.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/rejowan/pdfreaderpro/presentation/screens/settings/SettingsScreenContent.kt
+++ b/app/src/main/java/com/rejowan/pdfreaderpro/presentation/screens/settings/SettingsScreenContent.kt
@@ -1875,9 +1875,24 @@ private fun ChangelogContent() {
                 .verticalScroll(rememberScrollState())
         ) {
             ChangelogVersionItem(
+                version = "2.3.0",
+                date = "July 2026",
+                isLatest = true,
+                changes = listOf(
+                    "Setting to hide the page slider that appears while scrolling",
+                    "In-PDF search now steps through every match across all pages",
+                    "Active search match is centered in the view",
+                    "Fixed some PDFs failing to open when the file path had an apostrophe",
+                    "Updated core libraries (Kotlin, AGP, Android SDK 37)"
+                )
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            ChangelogVersionItem(
                 version = "2.2.0",
                 date = "April 2026",
-                isLatest = true,
+                isLatest = false,
                 changes = listOf(
                     "AMOLED black theme option",
                     "Customizable double-tap zoom level (1.1×–5×)",


### PR DESCRIPTION
Release preparation for **v2.3.0** (versionCode 8).

### Changes
- `app/build.gradle.kts` — versionCode 7 → 8, versionName 2.2.0 → 2.3.0
- `CHANGELOG.md` — new 2.3.0 section
- `SettingsScreenContent.kt` — new in-app changelog entry for 2.3.0 (2.2.0 flipped to non-latest)
- `KNOWN_ISSUES.md` — documents the non-English `/ToUnicode` search limitation (#40) and records the #57 open-failure + search-navigation fixes

### What's in 2.3.0 (since 2.2.0)
- Added: "Page Slider on Scroll" setting, off by default (#54)
- Changed: in-PDF search steps through every match and centers the active match (#40 navigation); dependency updates (Kotlin 2.4.10, AGP 9.2.1, SDK 37, …)
- Fixed: PDFs with an apostrophe in the file path failing to open (#57)

After merge: tag `v2.3.0` and publish the GitHub release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a page slider visibility option for scrolling while the toolbar is hidden.
  * Improved in-PDF search navigation across matches on different pages.
* **Bug Fixes**
  * Fixed PDFs getting stuck on the loading screen when their file paths contain apostrophes.
* **Documentation**
  * Added release notes for version 2.3.0.
  * Documented a known issue affecting search or copied text in some non-English PDFs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->