### PR TITLE
feat: tap-to-turn-page navigation for the reader

### DIFF
--- a/app/src/main/assets/com/rejowan/mozilla/pdfjs/helper_main.js
+++ b/app/src/main/assets/com/rejowan/mozilla/pdfjs/helper_main.js
@@ -161,9 +161,12 @@ function doOnLast() {
         if (isContextMenuActive) {
             isContextMenuActive = false;
         } else if (e.detail === 1) {
+            const rect = viewerContainer.getBoundingClientRect();
+            const x = e.clientX - rect.left;
+            const y = e.clientY - rect.top;
             singleClickTimer = setTimeout(() => {
                 if (e.target.tagName === "A") JWI.onLinkClick(e.target.href);
-                else JWI.onSingleClick();
+                else JWI.onSingleClick(x, y, rect.width, rect.height);
             }, DOUBLE_CLICK_THRESHOLD);
         }
     });

--- a/app/src/main/assets/com/rejowan/mozilla/pdfjs/jwi_interface.js
+++ b/app/src/main/assets/com/rejowan/mozilla/pdfjs/jwi_interface.js
@@ -15,7 +15,7 @@ try {
         onPageRendered() { },
         onPasswordDialogChange() { },
         onLinkClick() { },
-        onSingleClick() { },
+        onSingleClick(x, y, width, height) { },
         getValidCustomProtocols() { return ""; },
         onDoubleClick(x, y) { },
         onLongClick() { },

--- a/app/src/main/java/com/rejowan/pdfreaderpro/data/repository/PreferencesRepositoryImpl.kt
+++ b/app/src/main/java/com/rejowan/pdfreaderpro/data/repository/PreferencesRepositoryImpl.kt
@@ -45,6 +45,7 @@ class PreferencesRepositoryImpl(
         val READER_SNAP_TO_PAGES = booleanPreferencesKey("reader_snap_to_pages")
         val READER_SCRUBBER_ON_SCROLL = booleanPreferencesKey("reader_scrubber_on_scroll")
         val READER_SCREEN_ORIENTATION = stringPreferencesKey("reader_screen_orientation")
+        val READER_TAP_TO_TURN_PAGE = booleanPreferencesKey("reader_tap_to_turn_page")
     }
 
     override val preferences: Flow<AppPreferences> = dataStore.data.map { prefs ->
@@ -69,7 +70,8 @@ class PreferencesRepositoryImpl(
             readerTheme = prefs[Keys.READER_THEME]?.let { ReadingTheme.valueOf(it) } ?: ReadingTheme.LIGHT,
             readerSnapToPages = prefs[Keys.READER_SNAP_TO_PAGES] ?: false,
             readerScrubberOnScroll = prefs[Keys.READER_SCRUBBER_ON_SCROLL] ?: false,
-            readerScreenOrientation = prefs[Keys.READER_SCREEN_ORIENTATION]?.let { ScreenOrientation.valueOf(it) } ?: ScreenOrientation.AUTO
+            readerScreenOrientation = prefs[Keys.READER_SCREEN_ORIENTATION]?.let { ScreenOrientation.valueOf(it) } ?: ScreenOrientation.AUTO,
+            readerTapToTurnPage = prefs[Keys.READER_TAP_TO_TURN_PAGE] ?: false
         )
     }
 
@@ -145,5 +147,9 @@ class PreferencesRepositoryImpl(
 
     override suspend fun setReaderScreenOrientation(orientation: ScreenOrientation) {
         dataStore.edit { it[Keys.READER_SCREEN_ORIENTATION] = orientation.name }
+    }
+
+    override suspend fun setReaderTapToTurnPage(enabled: Boolean) {
+        dataStore.edit { it[Keys.READER_TAP_TO_TURN_PAGE] = enabled }
     }
 }

--- a/app/src/main/java/com/rejowan/pdfreaderpro/domain/model/AppPreferences.kt
+++ b/app/src/main/java/com/rejowan/pdfreaderpro/domain/model/AppPreferences.kt
@@ -21,7 +21,8 @@ data class AppPreferences(
     val readerTheme: ReadingTheme = ReadingTheme.LIGHT,
     val readerSnapToPages: Boolean = false,
     val readerScrubberOnScroll: Boolean = false,
-    val readerScreenOrientation: ScreenOrientation = ScreenOrientation.AUTO
+    val readerScreenOrientation: ScreenOrientation = ScreenOrientation.AUTO,
+    val readerTapToTurnPage: Boolean = false
 )
 
 enum class ThemeMode {

--- a/app/src/main/java/com/rejowan/pdfreaderpro/domain/repository/PreferencesRepository.kt
+++ b/app/src/main/java/com/rejowan/pdfreaderpro/domain/repository/PreferencesRepository.kt
@@ -35,4 +35,5 @@ interface PreferencesRepository {
     suspend fun setReaderSnapToPages(enabled: Boolean)
     suspend fun setReaderScrubberOnScroll(enabled: Boolean)
     suspend fun setReaderScreenOrientation(orientation: ScreenOrientation)
+    suspend fun setReaderTapToTurnPage(enabled: Boolean)
 }

--- a/app/src/main/java/com/rejowan/pdfreaderpro/presentation/components/pdf/Extensions.kt
+++ b/app/src/main/java/com/rejowan/pdfreaderpro/presentation/components/pdf/Extensions.kt
@@ -114,7 +114,7 @@ fun PdfViewer.addListener(
     onScrollModeChange: ((scrollMode: PdfViewer.PageScrollMode) -> Unit)? = null,
     onSpreadModeChange: ((spreadMode: PdfViewer.PageSpreadMode) -> Unit)? = null,
     onRotationChange: ((rotation: PdfViewer.PageRotation) -> Unit)? = null,
-    onSingleClick: (() -> Unit)? = null,
+    onSingleClick: ((x: Float, y: Float, width: Float, height: Float) -> Unit)? = null,
     onDoubleClick: ((x: Float, y: Float) -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
     onLinkClick: ((link: String) -> Unit)? = null,
@@ -231,8 +231,8 @@ fun PdfViewer.addListener(
             onRotationChange?.invoke(rotation)
         }
 
-        override fun onSingleClick() {
-            onSingleClick?.invoke()
+        override fun onSingleClick(x: Float, y: Float, width: Float, height: Float) {
+            onSingleClick?.invoke(x, y, width, height)
         }
 
         override fun onDoubleClick(x: Float, y: Float) {

--- a/app/src/main/java/com/rejowan/pdfreaderpro/presentation/components/pdf/PdfListener.kt
+++ b/app/src/main/java/com/rejowan/pdfreaderpro/presentation/components/pdf/PdfListener.kt
@@ -144,8 +144,12 @@ interface PdfListener {
 
     /**
      * Called on a single tap on the view.
+     * @param x The tap X coordinate in CSS pixels, relative to the viewer container's top-left.
+     * @param y The tap Y coordinate in CSS pixels, relative to the viewer container's top-left.
+     * @param width The viewer container's width in CSS pixels.
+     * @param height The viewer container's height in CSS pixels.
      */
-    fun onSingleClick() {}
+    fun onSingleClick(x: Float, y: Float, width: Float, height: Float) {}
 
     /**
      * Called on a double tap on the view.

--- a/app/src/main/java/com/rejowan/pdfreaderpro/presentation/components/pdf/WebInterface.kt
+++ b/app/src/main/java/com/rejowan/pdfreaderpro/presentation/components/pdf/WebInterface.kt
@@ -113,8 +113,8 @@ internal class WebInterface(private val pdfViewer: PdfViewer) {
     }
 
     @JavascriptInterface
-    fun onSingleClick() = post {
-        pdfViewer.listeners.forEach { it.onSingleClick() }
+    fun onSingleClick(x: Float, y: Float, width: Float, height: Float) = post {
+        pdfViewer.listeners.forEach { it.onSingleClick(x, y, width, height) }
     }
 
     @JavascriptInterface

--- a/app/src/main/java/com/rejowan/pdfreaderpro/presentation/components/pdfcompose/Extensions.kt
+++ b/app/src/main/java/com/rejowan/pdfreaderpro/presentation/components/pdfcompose/Extensions.kt
@@ -261,7 +261,7 @@ fun PdfState.rotationFlow(): Flow<PdfViewerView.PageRotation> = flowIt { emit ->
  */
 fun PdfState.singleClickFlow(): Flow<Unit> = flowIt { emit ->
     object : PdfListener {
-        override fun onSingleClick() {
+        override fun onSingleClick(x: Float, y: Float, width: Float, height: Float) {
             emit(Unit)
         }
     }

--- a/app/src/main/java/com/rejowan/pdfreaderpro/presentation/screens/reader/ReaderScreen.kt
+++ b/app/src/main/java/com/rejowan/pdfreaderpro/presentation/screens/reader/ReaderScreen.kt
@@ -537,6 +537,7 @@ fun ReaderScreen(
             isSnapEnabled = state.isSnapEnabled,
             isAutoHideToolbar = state.autoHideToolbar,
             isScrubberOnScroll = state.scrubberOnScroll,
+            isTapToTurnPage = state.tapToTurnPage,
             onScrollModeChange = { mode ->
                 viewModel.onAction(ReaderAction.SetScrollMode(mode))
             },
@@ -548,6 +549,9 @@ fun ReaderScreen(
             },
             onScrubberOnScrollToggle = { enabled ->
                 viewModel.onAction(ReaderAction.SetScrubberOnScroll(enabled))
+            },
+            onTapToTurnPageToggle = { enabled ->
+                viewModel.onAction(ReaderAction.SetTapToTurnPage(enabled))
             },
             onDismiss = { viewModel.onAction(ReaderAction.HideViewModeSheet) }
         )

--- a/app/src/main/java/com/rejowan/pdfreaderpro/presentation/screens/reader/ReaderState.kt
+++ b/app/src/main/java/com/rejowan/pdfreaderpro/presentation/screens/reader/ReaderState.kt
@@ -84,6 +84,9 @@ data class ReaderState(
     // Show the page scrubber on scroll while the toolbar is hidden
     val scrubberOnScroll: Boolean = false,
 
+    // Tap the sides of the page to move between pages
+    val tapToTurnPage: Boolean = false,
+
     // PDF info dialog
     val isInfoDialogVisible: Boolean = false,
 
@@ -171,6 +174,11 @@ sealed class ReaderAction {
     data object NextPage : ReaderAction()
     data object PreviousPage : ReaderAction()
 
+    // A single tap on the page: turn the page when tap-to-turn is enabled and the tap
+    // lands in an edge zone, otherwise toggle the toolbar. Coordinates and dimensions are
+    // in CSS pixels relative to the viewer container's top-left.
+    data class TapToTurnOrToggle(val x: Float, val y: Float, val width: Float, val height: Float) : ReaderAction()
+
     // Zoom
     data class SetZoom(val zoom: Float) : ReaderAction()
     data object ZoomIn : ReaderAction()
@@ -216,6 +224,7 @@ sealed class ReaderAction {
     data class SetReadingTheme(val theme: ReadingTheme) : ReaderAction()
     data class SetAutoHideToolbar(val enabled: Boolean) : ReaderAction()
     data class SetScrubberOnScroll(val enabled: Boolean) : ReaderAction()
+    data class SetTapToTurnPage(val enabled: Boolean) : ReaderAction()
     data class OpenLink(val url: String) : ReaderAction()
 
     // Search

--- a/app/src/main/java/com/rejowan/pdfreaderpro/presentation/screens/reader/ReaderViewModel.kt
+++ b/app/src/main/java/com/rejowan/pdfreaderpro/presentation/screens/reader/ReaderViewModel.kt
@@ -83,6 +83,7 @@ class ReaderViewModel(
                     readingTheme = mapDomainReadingTheme(prefs.readerTheme),
                     autoHideToolbar = prefs.readerAutoHideToolbar,
                     scrubberOnScroll = prefs.readerScrubberOnScroll,
+                    tapToTurnPage = prefs.readerTapToTurnPage,
                     keepScreenOn = prefs.readerKeepScreenOn,
                     isSnapEnabled = prefs.readerSnapToPages,
                     screenOrientation = mapDomainScreenOrientation(prefs.readerScreenOrientation),
@@ -275,8 +276,8 @@ class ReaderViewModel(
                     }
                 }
             },
-            onSingleClick = {
-                onAction(ReaderAction.ToggleToolbar)
+            onSingleClick = { x, y, width, height ->
+                onAction(ReaderAction.TapToTurnOrToggle(x, y, width, height))
             },
             onDoubleClick = { x, y ->
                 viewer.let { v ->
@@ -385,6 +386,39 @@ class ReaderViewModel(
         pdfViewer?.goToPage(item.page + 1)
     }
 
+    /**
+     * Handles a single tap on the page. When tap-to-turn is enabled and the tap lands in an
+     * edge zone, navigate between pages; otherwise fall back to toggling the toolbar.
+     *
+     * The turn direction follows the scroll orientation: vertical scrolling uses the top and
+     * bottom thirds (top = previous, bottom = next), horizontal scrolling uses the left and
+     * right thirds (left = previous, right = next). The middle third always toggles the toolbar.
+     */
+    private fun handleTapToTurnOrToggle(action: ReaderAction.TapToTurnOrToggle) {
+        val state = _state.value
+
+        // Fall back to toolbar toggle when the feature is off, auto-scroll is running
+        // (tap should pause instead), or dimensions are missing (avoid divide-by-zero).
+        if (!state.tapToTurnPage || state.isAutoScrollActive ||
+            action.width <= 0f || action.height <= 0f
+        ) {
+            onAction(ReaderAction.ToggleToolbar)
+            return
+        }
+
+        val position = if (state.scrollMode == ScrollMode.HORIZONTAL) {
+            action.x / action.width
+        } else {
+            action.y / action.height
+        }
+
+        when {
+            position < TAP_TURN_ZONE_FRACTION -> onAction(ReaderAction.PreviousPage)
+            position > 1f - TAP_TURN_ZONE_FRACTION -> onAction(ReaderAction.NextPage)
+            else -> onAction(ReaderAction.ToggleToolbar)
+        }
+    }
+
     private suspend fun addToRecent() {
         val file = File(pdfPath)
         recentRepository.addOrUpdateRecent(
@@ -409,6 +443,7 @@ class ReaderViewModel(
             is ReaderAction.PreviousPage -> {
                 pdfViewer?.goToPreviousPage()
             }
+            is ReaderAction.TapToTurnOrToggle -> handleTapToTurnOrToggle(action)
 
             is ReaderAction.SetZoom -> {
                 _state.update { it.copy(zoom = action.zoom.coerceIn(it.minZoom, it.maxZoom)) }
@@ -568,6 +603,13 @@ class ReaderViewModel(
                 _state.update { it.copy(scrubberOnScroll = action.enabled) }
                 viewModelScope.launch {
                     preferencesRepository.setReaderScrubberOnScroll(action.enabled)
+                }
+            }
+
+            is ReaderAction.SetTapToTurnPage -> {
+                _state.update { it.copy(tapToTurnPage = action.enabled) }
+                viewModelScope.launch {
+                    preferencesRepository.setReaderTapToTurnPage(action.enabled)
                 }
             }
 
@@ -984,5 +1026,11 @@ class ReaderViewModel(
 
     fun getDocumentFileName(): String {
         return File(pdfPath).name
+    }
+
+    private companion object {
+        // Fraction of the page's leading/trailing edge that acts as a page-turn tap zone.
+        // The middle (1 - 2 * fraction) toggles the toolbar instead.
+        const val TAP_TURN_ZONE_FRACTION = 1f / 3f
     }
 }

--- a/app/src/main/java/com/rejowan/pdfreaderpro/presentation/screens/reader/components/ViewModeSheet.kt
+++ b/app/src/main/java/com/rejowan/pdfreaderpro/presentation/screens/reader/components/ViewModeSheet.kt
@@ -41,6 +41,7 @@ import androidx.compose.material.icons.rounded.LinearScale
 import androidx.compose.material.icons.rounded.SwapHoriz
 import androidx.compose.material.icons.rounded.SwapVert
 import androidx.compose.material.icons.rounded.Timer
+import androidx.compose.material.icons.rounded.TouchApp
 import androidx.compose.material.icons.rounded.ViewDay
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -85,10 +86,12 @@ fun ViewModeSheet(
     isSnapEnabled: Boolean,
     isAutoHideToolbar: Boolean,
     isScrubberOnScroll: Boolean,
+    isTapToTurnPage: Boolean,
     onScrollModeChange: (ScrollMode) -> Unit,
     onSnapToggle: (Boolean) -> Unit,
     onAutoHideToolbarToggle: (Boolean) -> Unit,
     onScrubberOnScrollToggle: (Boolean) -> Unit,
+    onTapToTurnPageToggle: (Boolean) -> Unit,
     onDismiss: () -> Unit
 ) {
     val configuration = LocalConfiguration.current
@@ -100,10 +103,12 @@ fun ViewModeSheet(
             isSnapEnabled = isSnapEnabled,
             isAutoHideToolbar = isAutoHideToolbar,
             isScrubberOnScroll = isScrubberOnScroll,
+            isTapToTurnPage = isTapToTurnPage,
             onScrollModeChange = onScrollModeChange,
             onSnapToggle = onSnapToggle,
             onAutoHideToolbarToggle = onAutoHideToolbarToggle,
             onScrubberOnScrollToggle = onScrubberOnScrollToggle,
+            onTapToTurnPageToggle = onTapToTurnPageToggle,
             onDismiss = onDismiss
         )
     } else {
@@ -112,10 +117,12 @@ fun ViewModeSheet(
             isSnapEnabled = isSnapEnabled,
             isAutoHideToolbar = isAutoHideToolbar,
             isScrubberOnScroll = isScrubberOnScroll,
+            isTapToTurnPage = isTapToTurnPage,
             onScrollModeChange = onScrollModeChange,
             onSnapToggle = onSnapToggle,
             onAutoHideToolbarToggle = onAutoHideToolbarToggle,
             onScrubberOnScrollToggle = onScrubberOnScrollToggle,
+            onTapToTurnPageToggle = onTapToTurnPageToggle,
             onDismiss = onDismiss
         )
     }
@@ -128,10 +135,12 @@ private fun ViewModeBottomSheet(
     isSnapEnabled: Boolean,
     isAutoHideToolbar: Boolean,
     isScrubberOnScroll: Boolean,
+    isTapToTurnPage: Boolean,
     onScrollModeChange: (ScrollMode) -> Unit,
     onSnapToggle: (Boolean) -> Unit,
     onAutoHideToolbarToggle: (Boolean) -> Unit,
     onScrubberOnScrollToggle: (Boolean) -> Unit,
+    onTapToTurnPageToggle: (Boolean) -> Unit,
     onDismiss: () -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState()
@@ -148,10 +157,12 @@ private fun ViewModeBottomSheet(
             isSnapEnabled = isSnapEnabled,
             isAutoHideToolbar = isAutoHideToolbar,
             isScrubberOnScroll = isScrubberOnScroll,
+            isTapToTurnPage = isTapToTurnPage,
             onScrollModeChange = onScrollModeChange,
             onSnapToggle = onSnapToggle,
             onAutoHideToolbarToggle = onAutoHideToolbarToggle,
             onScrubberOnScrollToggle = onScrubberOnScrollToggle,
+            onTapToTurnPageToggle = onTapToTurnPageToggle,
             modifier = Modifier.padding(bottom = 24.dp)
         )
     }
@@ -163,10 +174,12 @@ private fun ViewModeSideSheet(
     isSnapEnabled: Boolean,
     isAutoHideToolbar: Boolean,
     isScrubberOnScroll: Boolean,
+    isTapToTurnPage: Boolean,
     onScrollModeChange: (ScrollMode) -> Unit,
     onSnapToggle: (Boolean) -> Unit,
     onAutoHideToolbarToggle: (Boolean) -> Unit,
     onScrubberOnScrollToggle: (Boolean) -> Unit,
+    onTapToTurnPageToggle: (Boolean) -> Unit,
     onDismiss: () -> Unit
 ) {
     var isVisible by remember { mutableStateOf(false) }
@@ -219,10 +232,12 @@ private fun ViewModeSideSheet(
                     isSnapEnabled = isSnapEnabled,
                     isAutoHideToolbar = isAutoHideToolbar,
                     isScrubberOnScroll = isScrubberOnScroll,
+                    isTapToTurnPage = isTapToTurnPage,
                     onScrollModeChange = onScrollModeChange,
                     onSnapToggle = onSnapToggle,
                     onAutoHideToolbarToggle = onAutoHideToolbarToggle,
                     onScrubberOnScrollToggle = onScrubberOnScrollToggle,
+                    onTapToTurnPageToggle = onTapToTurnPageToggle,
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(
@@ -242,10 +257,12 @@ private fun ViewModeSheetContent(
     isSnapEnabled: Boolean,
     isAutoHideToolbar: Boolean,
     isScrubberOnScroll: Boolean,
+    isTapToTurnPage: Boolean,
     onScrollModeChange: (ScrollMode) -> Unit,
     onSnapToggle: (Boolean) -> Unit,
     onAutoHideToolbarToggle: (Boolean) -> Unit,
     onScrubberOnScrollToggle: (Boolean) -> Unit,
+    onTapToTurnPageToggle: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -329,6 +346,18 @@ private fun ViewModeSheetContent(
             onToggle = onScrubberOnScrollToggle,
             accentColor = AccentTeal,
             animationDelay = 250
+        )
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        ToggleRow(
+            icon = Icons.Rounded.TouchApp,
+            title = stringResource(R.string.tap_to_turn_page),
+            description = stringResource(R.string.tap_to_turn_page_desc),
+            isEnabled = isTapToTurnPage,
+            onToggle = onTapToTurnPageToggle,
+            accentColor = AccentTeal,
+            animationDelay = 300
         )
     }
 }

--- a/app/src/main/java/com/rejowan/pdfreaderpro/presentation/screens/settings/SettingsScreenContent.kt
+++ b/app/src/main/java/com/rejowan/pdfreaderpro/presentation/screens/settings/SettingsScreenContent.kt
@@ -72,6 +72,7 @@ import androidx.compose.material.icons.rounded.StayCurrentLandscape
 import androidx.compose.material.icons.rounded.StayCurrentPortrait
 import androidx.compose.material.icons.rounded.SwapHoriz
 import androidx.compose.material.icons.rounded.SwapVert
+import androidx.compose.material.icons.rounded.TouchApp
 import androidx.compose.material.icons.rounded.ViewDay
 import androidx.compose.material.icons.rounded.VisibilityOff
 import androidx.compose.material.icons.rounded.Schedule
@@ -338,6 +339,18 @@ fun SettingsScreenContent(
             checked = preferences.readerSnapToPages,
             onCheckedChange = { viewModel.setReaderSnapToPages(it) },
             animationDelay = 385
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        SettingsToggleItem(
+            icon = Icons.Rounded.TouchApp,
+            title = stringResource(R.string.tap_to_turn_page),
+            subtitle = stringResource(R.string.tap_to_turn_page_desc),
+            accentColor = AccentBlue,
+            checked = preferences.readerTapToTurnPage,
+            onCheckedChange = { viewModel.setReaderTapToTurnPage(it) },
+            animationDelay = 392
         )
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/rejowan/pdfreaderpro/presentation/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/rejowan/pdfreaderpro/presentation/screens/settings/SettingsViewModel.kt
@@ -346,4 +346,10 @@ class SettingsViewModel(
             preferencesRepository.setReaderScreenOrientation(orientation)
         }
     }
+
+    fun setReaderTapToTurnPage(enabled: Boolean) {
+        viewModelScope.launch {
+            preferencesRepository.setReaderTapToTurnPage(enabled)
+        }
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -744,6 +744,8 @@
     <string name="auto_hide_toolbar_desc">Hide toolbar after 5 seconds</string>
     <string name="scrubber_on_scroll">Page Slider on Scroll</string>
     <string name="scrubber_on_scroll_desc">Show the page slider while scrolling when the toolbar is hidden</string>
+    <string name="tap_to_turn_page">Tap to Turn Page</string>
+    <string name="tap_to_turn_page_desc">Tap the sides of the page to move between pages</string>
 
     <!-- Display Sheet -->
     <string name="display_settings">Display Settings</string>


### PR DESCRIPTION
Closes #62

## What
Adds tap-to-turn-page navigation to the PDF reader.

- Tap the **edge thirds** of the page to turn pages; the **middle third** still toggles the toolbar.
- Tap zones follow the scroll orientation:
  - **Vertical** scrolling → top third = previous, bottom third = next
  - **Horizontal** scrolling → left third = previous, right third = next
- Gated behind a new **"Tap to Turn Page"** preference (default **off**), exposed in **both** the Settings reader section and the in-reader View Options sheet.

## How
Threads tap coordinates through `onSingleClick(x, y, width, height)`, mirroring the existing `onDoubleClick(x, y)` mechanism. Tap-zone routing lives in `ReaderViewModel.handleTapToTurnOrToggle`. New `readerTapToTurnPage` DataStore preference persists the setting.

## Notes
- Default off, so existing users see no behavior change until they enable it.
- Falls back to toolbar-toggle when disabled, during auto-scroll, or if viewer dimensions are unavailable.
- `./gradlew compileDebugKotlin` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional “Tap to turn page” setting in Reader and Settings.
  * Tapping the page edges can now navigate to the previous or next page.
  * Taps in other areas continue to toggle the reader toolbar.
  * The preference is saved and restored between sessions.
  * Improved tap handling with position-aware interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->