### PR TITLE
Prepare 2.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.4.0] - 2026-08-15
+
+### Added
+- **Text Highlights** - Select any text and highlight it in one of five colours from the action bar that appears below the selection; highlights are saved per document and restored when the file is reopened (closes #41)
+- **Highlights Panel** - Lists every highlight with its text, page and colour, searchable and filterable by colour; tapping an entry jumps to it and pulses it
+- **Highlight Navigation** - Next/previous strip that steps through highlights in reading order and wraps at both ends
+- **Search and Highlights** - The in-PDF search bar shows how many of the current matches are already highlighted; tapping that count opens the panel filtered to the same query
+- **Save a Copy with Highlights** - Writes highlights into a new PDF as real annotations so they appear in other PDF readers; the original file is never modified, and the action is confirmed with a checkbox
+- **Highlights Already in a File** - Highlights the PDF itself carries, whether exported from this app or added elsewhere, are now listed, searchable and included in navigation; they are read only, since editing them would mean rewriting the document
+- **Lock Horizontal Scroll** - Setting (View Options) that holds the page where it is when zoomed in, saved per document; available in vertical scroll mode only (closes #74)
+
+### Changed
+- **Selection Menu** - Highlighting is now a single tap from the app's own bar below the selection, rather than being reached through the system menu's overflow; the system menu is unchanged
+
+### Fixed
+- **Viewer Layout** - Hardened the viewer against a latent sidebar offset that could shift the page sideways with nothing visible in the gap
+
+---
+
 ## [2.3.0] - 2026-07-19
 
 ### Added

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -35,11 +35,22 @@ This document lists known issues and limitations in PDF Reader Pro, along with w
 ---
 
 ### Search or copy returns wrong text in some non-English PDFs
-**Issue:** In some PDFs (often Indic scripts such as Hindi, Bengali, or Gujarati) the text renders correctly, but search, text selection, and copy return incorrect or scrambled characters. This happens when the PDF's embedded fonts carry an incomplete or incorrect `/ToUnicode` map — the correct characters are simply not stored in the file, so no reader can recover them.
+**Issue:** In some PDFs (often Indic scripts such as Hindi, Bengali, or Gujarati) the text renders correctly, but search, text selection, copy, and highlighting return incorrect or scrambled characters. Highlights are affected because they are made from a text selection, so a highlight may cover the right words on the page while listing the wrong text in the Highlights panel. This happens when the PDF's embedded fonts carry an incomplete or incorrect `/ToUnicode` map — the correct characters are simply not stored in the file, so no reader can recover them.
 
 **Workaround:** Re-generate the PDF with a tool that embeds proper Unicode data (for example, "Print → Save as PDF" from Chrome). Note this affects every PDF viewer (including Adobe Reader and Chrome), not just this app.
 
 **Status:** Limitation of the PDF file itself, not fixable in the reader (#40)
+
+---
+
+## Highlights
+
+### Highlights already in a file may list slightly more or less text than they cover
+**Issue:** Highlights that came with the PDF, whether exported from this app or added by another application, record where they are on the page but not which words they cover. The text shown for them in the Highlights panel is recovered by reading the page underneath, and the PDF text layer gives one run per line rather than per word, so the recovered text is estimated from where the highlight falls along the line. On unusual fonts or heavy kerning this can clip a word short or include a neighbouring one.
+
+**Workaround:** None needed for reading; the highlight itself is drawn in exactly the right place. Only the text listed in the panel, and therefore what it matches in search, is approximate.
+
+**Status:** Limitation of the data available from the PDF text layer. Highlights created in this app are unaffected, since their text is captured from the selection.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,16 @@ GNU General Public License for more details.
 
 ## Changelog
 
+### v2.4.0 (2026-08-15)
+
+- Highlight text in five colours, saved per document (#41)
+- Highlights panel with search, colour filter and jump-to-highlight (#41)
+- Next/previous navigation between highlights (#41)
+- In-PDF search shows how many matches are already highlighted (#41)
+- Save a copy with highlights written into the PDF as real annotations (#41)
+- Highlights already present in a file are listed and searchable, read only (#41)
+- Lock horizontal scroll when zoomed in, saved per document (#74)
+
 ### v2.3.0 (2026-07-19)
 
 - Setting to hide the page slider that appears while scrolling (#54)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.rejowan.pdfreaderpro"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 8
-        versionName = "2.3.0"
+        versionCode = 9
+        versionName = "2.4.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/rejowan/pdfreaderpro/presentation/screens/settings/SettingsScreenContent.kt
+++ b/app/src/main/java/com/rejowan/pdfreaderpro/presentation/screens/settings/SettingsScreenContent.kt
@@ -1888,9 +1888,26 @@ private fun ChangelogContent() {
                 .verticalScroll(rememberScrollState())
         ) {
             ChangelogVersionItem(
+                version = "2.4.0",
+                date = "August 2026",
+                isLatest = true,
+                changes = listOf(
+                    "Highlight text in five colours, saved per document",
+                    "Highlights panel with search, colour filter and jump-to-highlight",
+                    "Next/previous navigation between highlights",
+                    "In-PDF search shows how many matches are already highlighted",
+                    "Save a copy with highlights written into the PDF",
+                    "Highlights already in a file are listed and searchable, read only",
+                    "Lock horizontal scroll when zoomed in, saved per document"
+                )
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            ChangelogVersionItem(
                 version = "2.3.0",
                 date = "July 2026",
-                isLatest = true,
+                isLatest = false,
                 changes = listOf(
                     "Setting to hide the page slider that appears while scrolling",
                     "In-PDF search now steps through every match across all pages",


### PR DESCRIPTION
Version bump and release notes for 2.4.0, on top of the highlights work merged in #75.

**Minor, not patch.** `CHANGELOG.md` states the project follows Semantic Versioning,
where patch is for backwards-compatible bug fixes. This release adds a feature with
its own storage and export path, a new per-document setting, and two database
migrations. Repo history matches: 2.1.0, 2.2.0 and 2.3.0 were feature releases, while
2.1.1 and 2.1.3 were build and F-Droid metadata fixes.

## Changes

- `app/build.gradle.kts` - versionCode 8 to 9, versionName 2.3.0 to 2.4.0
- `CHANGELOG.md` - `[2.4.0]` section
- `README.md` - `v2.4.0` entry
- `SettingsScreenContent.kt` - new entry in the in-app changelog, and 2.3.0's
  `isLatest` flag moved off it
- `KNOWN_ISSUES.md` - two limitations recorded

## Notes

Everywhere the app displays its own version reads `BuildConfig.VERSION_NAME`, so the
in-app changelog list is the only place carrying a literal version string. `fastlane/`
was removed in 2.2.0, so there are no per-version changelog files to add.

Two limitations are written into `KNOWN_ISSUES.md` rather than left to be
rediscovered:

- The existing `/ToUnicode` entry now notes that highlighting is affected as well.
  A highlight is made from a text selection, so on those PDFs it can cover the right
  words on the page while listing the wrong text in the panel.
- Highlights that came with a file list approximate text. The annotation records
  where it sits, not which words it covers, and the PDF text layer gives one run per
  line rather than per word, so the text is estimated from where the highlight falls
  along the line. Highlights created in the app are unaffected, since their text comes
  from the selection.

## Testing

1021 unit tests, `assembleDebug` and `lintDebug` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added text highlighting with highlight management and navigation.
  * Added search integration for locating highlighted text.
  * Added export of highlighted PDF copies.
  * Added support for viewing existing PDF highlights in read-only mode.
  * Added per-document horizontal-scroll locking.
  * Updated the selection menu and improved viewer layout.

* **Bug Fixes**
  * Expanded known-issue guidance for inaccurate text extraction affecting search and highlights in some non-English PDFs.

* **Documentation**
  * Published the v2.4.0 release notes across the app and project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->